### PR TITLE
Scrutinizer Auto-Fixes

### DIFF
--- a/src/PHPRealCoverage/Mutator/MutationGenerator.php
+++ b/src/PHPRealCoverage/Mutator/MutationGenerator.php
@@ -37,6 +37,10 @@ class MutationGenerator
         return array_reverse($affectedLines);
     }
 
+    /**
+     * @param integer $lineNumber
+     * @param MutatableLine[] $mutatableLines
+     */
     public function addCommandForLine($lineNumber, $mutatableLines, &$affectedLines)
     {
         $line = $this->getLine($mutatableLines, $lineNumber);
@@ -72,7 +76,7 @@ class MutationGenerator
     /**
      * @param $mutatableLines
      * @param $i
-     * @return mixed
+     * @return MutatableLine
      * @throws Exception\NoMoreMutationsException
      */
     private function getLine($mutatableLines, $i)

--- a/src/PHPRealCoverage/Parser/ClassParser.php
+++ b/src/PHPRealCoverage/Parser/ClassParser.php
@@ -27,6 +27,9 @@ class ClassParser
         return $class;
     }
 
+    /**
+     * @param string $content
+     */
     public function parseName($content)
     {
         if (!preg_match(self::CLASSNAME_PATTERN, $content, $matches)) {
@@ -69,6 +72,9 @@ class ClassParser
         }
     }
 
+    /**
+     * @param string $content
+     */
     public function parseNamespace($content)
     {
         if (!preg_match(self::NAMESPACE_PATTERN, $content, $matches)) {

--- a/src/PHPRealCoverage/Parser/Model/CoveredClass.php
+++ b/src/PHPRealCoverage/Parser/Model/CoveredClass.php
@@ -30,13 +30,16 @@ class CoveredClass implements ClassMetadata
     }
 
     /**
-     * @return mixed
+     * @return string
      */
     public function getName()
     {
         return $this->name;
     }
 
+    /**
+     * @param integer $lineNumber
+     */
     public function addLine($lineNumber, Line $line)
     {
         $this->lines[$lineNumber] = $line;

--- a/src/PHPRealCoverage/Proxy/ProxyBuilder.php
+++ b/src/PHPRealCoverage/Proxy/ProxyBuilder.php
@@ -102,7 +102,7 @@ class ProxyBuilder
     }
 
     /**
-     * @param $method
+     * @param string $method
      * @internal param $proxyContent
      * @return string
      */


### PR DESCRIPTION
@julianseeger requested this pull request.

This patch was automatically generated as part of the following inspection:
https://scrutinizer-ci.com/g/julianseeger/php-real-coverage/inspections/2c013e0a-b656-4491-942b-d6d09b490645

Enabled analysis tools:
- PHP Analyzer
- PHP Mess Detector
- PHP Code Sniffer
- PHP CS Fixer
- PHP Code Coverage
- PHP Copy/Paste Detector
- PHP PDepend
